### PR TITLE
Update platform.io config to use new rpcWifi libs

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,18 +12,18 @@
 platform = atmelsam
 board = seeed_wio_terminal
 framework = arduino
-lib_deps = 
+lib_deps =
     Adafruit Zero DMA Library
     SPI
-    https://github.com/Seeed-Studio/Seeed_Arduino_atWiFi
+    seeed-studio/Seeed Arduino rpcWiFi @ 1.0.5
     https://github.com/Seeed-Studio/Seeed_Arduino_FreeRTOS
-    https://github.com/Seeed-Studio/Seeed_Arduino_atUnified
-    https://github.com/Seeed-Studio/esp-at-lib
-    https://github.com/Seeed-Studio/Seeed_Arduino_mbedtls
-    https://github.com/Seeed-Studio/Seeed_Arduino_atWiFiClientSecure
+    seeed-studio/Seeed Arduino rpcUnified @ 2.1.3
+    seeed-studio/Seeed_Arduino_mbedtls @ 3.0.1
+    seeed-studio/Seeed Arduino FS @ 2.1.1
+    seeed-studio/Seeed Arduino SFUD @ 2.0.2
     https://github.com/sstaub/NTP
     PubSubClient
     https://github.com/Seeed-Studio/Seeed_Arduino_LIS3DHTR
-build_flags = 
-    -DAZ_NO_LOGGING 
+build_flags =
+    -DAZ_NO_LOGGING
 #    -DEZTIME_CACHE_EEPROM=0


### PR DESCRIPTION
Hi there!  Was trying to build your sample while working on a project for the 2021 Hackathon, and ran in to some errors with mbedtls.  Digging around a little more, it turns out the seeed atWiFi libraries are deprecated in favor of the new rpcWiFi libraries.  Updating the libs to the new ones did the trick for the build issue, surprisingly everything else works fine exactly as is.  Not sure if you'll like the @ version style references, those were pulled from the [IoT For Beginners](https://github.com/microsoft/IoT-For-Beginners/blob/main/1-getting-started/lessons/4-connect-internet/wio-terminal-mqtt.md) tutorial docs.  :)